### PR TITLE
feat/user profile

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,13 +1,17 @@
 class RegistrationsController < ApplicationController
 
+  before_action :profile, only: :create
+
   def new
     @user = User.new
+    @profile = Profile.new
   end
 
   def create
-    @user = profile.build_user(registration_params)
+    @user = User.new(user_params)
+    @user.profile = @profile
 
-    if @user.valid?
+    if @user.valid? && @profile.valid?
       @user.save
       redirect_to root_path
     else
@@ -21,11 +25,11 @@ class RegistrationsController < ApplicationController
     @profile = Profile.new(profile_params)
   end
 
-  def registration_params
+  def user_params
     params.require(:user).permit(:email, :password, :password_confirmation)
   end
 
   def profile_params
-    params.require(:user).permit(:first_name, :last_name)
+    params.require(:profile).permit(:first_name, :last_name)
   end
 end

--- a/app/lib/storage_service.rb
+++ b/app/lib/storage_service.rb
@@ -14,7 +14,7 @@ class StorageService
   end
 
   def presigned_url
-    object.presigned_url(:put, presigned_url_params)
+    object.presigned_url(:put)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,5 @@ class User < ApplicationRecord
   belongs_to :profile
   has_secure_password
 
-  validates :email, uniqueness: true
+  validates :email, presence: true, uniqueness: true
 end

--- a/app/views/registrations/_form.html.erb
+++ b/app/views/registrations/_form.html.erb
@@ -1,16 +1,18 @@
 <%= form_with(model: @user, url: registrations_path) do |f| %>
   <div class="flex-col mb-4 space-y-2">
-    <div class="flex justify-between">
-      <div>
-        <%= f.label :first_name %>
-        <%= f.text_field :first_name, class: "w-full outline-none py-1 px-2 text-md border-2 rounded-md" %>
-      </div>
+    <%= fields_for :profile do |f| %>
+      <div class="flex justify-between">
+        <div>
+          <%= f.label :first_name %>
+          <%= f.text_field :first_name, class: "w-full outline-none py-1 px-2 text-md border-2 rounded-md" %>
+        </div>
 
-      <div>
-        <%= f.label :last_name %>
-        <%= f.text_field :last_name, class: "w-full outline-none py-1 px-2 text-md border-2 rounded-md" %>
+        <div>
+          <%= f.label :last_name %>
+          <%= f.text_field :last_name, class: "w-full outline-none py-1 px-2 text-md border-2 rounded-md" %>
+        </div>
       </div>
-    </div>
+    <% end %>
 
     <div>
       <%= f.label :email %>

--- a/app/views/registrations/_form.html.erb
+++ b/app/views/registrations/_form.html.erb
@@ -1,4 +1,14 @@
-<%= form_with(model: @user, url: registrations_path) do |f| %>
+<%= form_with(model: @user, url: signup_path) do |f| %>
+  <div>
+    <% @user.errors.full_messages.each do |message| %>
+      <p style="color: red"><%= message %></p>
+    <% end %>
+
+    <% @profile.errors.full_messages.each do |message| %>
+      <p style="color: red"><%= message %></p>
+    <% end %>
+  </div>
+
   <div class="flex-col mb-4 space-y-2">
     <%= fields_for :profile do |f| %>
       <div class="flex justify-between">
@@ -17,12 +27,6 @@
     <div>
       <%= f.label :email %>
       <%= f.text_field :email, class: "w-full outline-none py-1 px-2 text-md border-2 rounded-md" %>
-    </div>
-    
-    <div>
-      <% @user.errors.full_messages_for(:email).each do |message| %>
-        <p style="color: red"><%= message %></p>
-      <% end %>
     </div>
 
     <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   root "articles#index"
   
-  resources :registrations, only: :create
   get '/signup', to: 'registrations#new'
+  post '/signup', to: 'registrations#create'
   get '/signin', to: 'sessions#new'
   post '/sessions', to: 'sessions#create'
   post '/signout', to: 'sessions#destroy'

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Profile, type: :model do
     it 'without first name' do
       profile = FactoryBot.build(:profile, first_name: nil)
       expect(profile).to_not be_valid
-      # expect(profile.errors.full_messages).to eq(["First name can't be blank"])
+      expect(profile.errors.full_messages).to eq(["First name can't be blank"])
     end
 
     it 'without last name' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  context 'is valid' do
+    it 'with factory' do
+      user = FactoryBot.build(:user)
+      expect(user).to be_valid
+    end
+  end
+
+  context 'is not valid' do
+    it 'without email' do
+      user = FactoryBot.build(:user, email: nil)
+      expect(user).to_not be_valid
+      expect(user.errors.full_messages).to eq(["Email can't be blank"])
+    end
+
+    it 'without password' do
+      user = FactoryBot.build(:user, password: nil)
+      expect(user).to_not be_valid
+      expect(user.errors.full_messages).to eq(["Password can't be blank"])
+    end
+
+    it 'if email is not unique' do
+      commited_user = FactoryBot.create(:user)
+      registering_user = FactoryBot.build(:user, email: commited_user.email)
+      expect(registering_user).to_not be_valid
+      expect(registering_user.errors.full_messages).to eq(["Email has already been taken"])
+    end
+  end
+end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -9,11 +9,22 @@ RSpec.describe "Registrations", type: :request do
   end
 
   describe "POST /signup" do
-    it "responds with status 302" do
-      user_params = FactoryBot.attributes_for(:user)
-      profile_params = FactoryBot.attributes_for(:profile)
-      post signup_path, params: {user: user_params, profile: profile_params}
-      expect(response).to have_http_status(302)
+    context 'when params are valid' do
+      it "responds with status 302" do
+        user_params = FactoryBot.attributes_for(:user)
+        profile_params = FactoryBot.attributes_for(:profile)
+        post signup_path, params: {user: user_params, profile: profile_params}
+        expect(response).to have_http_status(302)
+      end
+    end
+
+    context 'when params are invalid' do
+      it "responds with status 422" do
+        user_params = FactoryBot.attributes_for(:user, email: nil)
+        profile_params = FactoryBot.attributes_for(:profile)
+        post signup_path, params: {user: user_params, profile: profile_params}
+        expect(response).to have_http_status(422)
+      end
     end
   end
 end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -7,4 +7,13 @@ RSpec.describe "Registrations", type: :request do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe "POST /signup" do
+    it "responds with status 302" do
+      user_params = FactoryBot.attributes_for(:user)
+      profile_params = FactoryBot.attributes_for(:profile)
+      post signup_path, params: {user: user_params, profile: profile_params}
+      expect(response).to have_http_status(302)
+    end
+  end
 end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Registrations", type: :request do
+  describe "GET /signup" do
+    it "responds with status 200" do
+      get signup_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :request do
+  describe "GET /signin" do
+    it "responds with a status of 200" do
+      get signin_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "POST /sessions" do
+    context 'when params are valid' do
+      it "responds with a status of 302" do
+        user = FactoryBot.create(:user)
+        post sessions_path, params: {email: user.email, password: user.password}
+        expect(response).to have_http_status(302)
+      end
+    end
+
+    context 'when params are invalid' do
+      it "responds with a status of 422" do
+        user = FactoryBot.create(:user)
+        post sessions_path, params: {email: "fake", password: user.password}
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when the user isn\'t registered' do
+      it 'responds with a status of 422' do
+        post sessions_path, params: {email: "fake@fake.com", password: "fake"}
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+
+  describe 'POST /signout' do
+    it "responds with a status of 302" do
+      post signout_path
+      expect(response).to have_http_status(302)
+    end
+  end
+end


### PR DESCRIPTION
- refact: profile instance for #new and #create
- feat: validates for presence of email
- feat: adds profile key for first name and last name fields
- feat: shows errors for profile
- test: checks for "First name can't be blank" error
- test: checks user is valid with factory and invalid without attributes
- refact: post /signup to registrations#create
- test: expect get /signup to respond with status 200
- test: expect post /signup responds with status 302
- test: post /signup with invalid params responds with 422
- test: session routes with valid and invalid params
- fix: typeo
