### PR TITLE
feat/only authenticated users can create articles

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,7 +1,7 @@
 class ArticlesController < ApplicationController
   include Pagination
 
-  before_action :authenticate_user!
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
 
   def index
     @pagination, @articles = paginate(collection: Article.all.order(created_at: :desc), params: remedy_page_param(page_params))

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -16,7 +16,7 @@ class ArticlesController < ApplicationController
   end
 
   def create
-    @article = Article.new(article_params)
+    @article = current_profile.articles.build(article_params)
 
     if @article.save
       redirect_to @article
@@ -27,10 +27,12 @@ class ArticlesController < ApplicationController
 
   def edit
     @article = find_article(params[:id])
+    is_unauthorized?(@article, "show")
   end
 
   def update
     @article = find_article(params[:id])
+    return if is_unauthorized?(@article, "show")
 
     if @article.update(article_params)
       redirect_to @article
@@ -41,6 +43,7 @@ class ArticlesController < ApplicationController
 
   def destroy
     @article = find_article(params[:id])
+    return if is_unauthorized?(@article, "show")
     @article.destroy
 
     redirect_to articles_path, status: :see_other
@@ -66,5 +69,13 @@ class ArticlesController < ApplicationController
     end
 
     params
+  end
+
+  def is_unauthorized?(article, destination)
+    destination = destination.to_sym
+    if article.profile.id != current_profile.id
+      render destination, status: :unauthorized
+      return true
+    end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,6 +1,8 @@
 class Article < ApplicationRecord
     require 'sanitize'
 
+    belongs_to :profile
+
     validates :title, presence: true
     validates :body, presence: true
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,5 +1,6 @@
 class Profile < ApplicationRecord
   has_one :user
+  has_many :articles
 
   validates :first_name, :last_name, presence: true
 end

--- a/db/migrate/20230919203508_add_foreign_key_to_articles.rb
+++ b/db/migrate/20230919203508_add_foreign_key_to_articles.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToArticles < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :articles, :profile
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_15_044732) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_19_203508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_15_044732) do
     t.datetime "updated_at", null: false
     t.string "slug"
     t.string "image_url"
+    t.bigint "profile_id"
+    t.index ["profile_id"], name: "index_articles_on_profile_id"
   end
 
   create_table "profiles", force: :cascade do |t|

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Article, type: :model do
+  let(:profile) { FactoryBot.create(:profile) }
+
   describe "is valid" do
     it "when title and body are present" do
-      article = FactoryBot.build(:article)
+      article = FactoryBot.build(:article, profile: profile)
 
       expect(article).to be_valid
     end
@@ -32,12 +34,11 @@ RSpec.describe Article, type: :model do
   end
 
   describe "#to_param" do
-    let(:article) {FactoryBot.build(:article, title: "Test Title")}
+    let(:article) {FactoryBot.build(:article, title: "Test Title", profile: profile)}
 
     context "given an Article that exists in the database" do
       it "returns the slug" do
         article.save
-
         expect(article.to_param).to eq(Article.first.slug)
       end
     end
@@ -53,19 +54,19 @@ RSpec.describe Article, type: :model do
     it "blacklisted elements are removed" do
       html = "<script></script>"
   
-      a = Article.new({:title => "Title", :body => html})
-      a.valid?
+      article = FactoryBot.build(:article, title: "Title", body: html)
+      article.valid?
   
-      expect(a.errors.full_messages_for :body).to include("Body can't be blank")
-      expect(a.body).to eq("")
+      expect(article.errors.full_messages_for :body).to include("Body can't be blank")
+      expect(article.body).to eq("")
     end
   
     it "allowlisted elements are not removed" do
       html = "<p>Heres is the Article body.</p>"
   
-      a = Article.new({:title => "Title", :body => html})
-      expect(a.valid?).to eq(true)
-      expect(a.body).to eq("<p>Heres is the Article body.</p>")
+      article = FactoryBot.build(:article, title: "Title", body: html, profile: profile)
+      expect(article.valid?).to eq(true)
+      expect(article.body).to eq("<p>Heres is the Article body.</p>")
     end
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "GET /articles/:id" do
-    let(:article) {FactoryBot.create(:article, title: "Test Title")}
+    let(:profile) { FactoryBot.create(:profile) }
+    let(:article) { FactoryBot.create(:article, title: "Test Title", profile: profile) }
 
     it "responds with :ok status when supplied slug" do
       get article_path(article.slug)
@@ -36,12 +37,13 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "POST /articles" do
+    let!(:profile) { FactoryBot.create(:profile) }
     let(:valid_params) { {article: {title: "title", body: "body"}} }
 
     context "with valid params" do 
-      it "responds with :redirect status" do
+      it "responds with status 302" do
         post articles_path, params: valid_params
-        expect(response).to have_http_status(:redirect)
+        expect(response).to have_http_status(302)
       end
       
       it "increases Articles count by 1" do
@@ -97,7 +99,9 @@ RSpec.describe "Articles", type: :request do
         post signout_path
         post sessions_path, params: {email: second_user.email, password: second_user.password}
         
-      expect(response).to have_http_status(:redirect)
+        put_article
+        expect(response).to have_http_status(401)
+      end
     end
   end
 

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe "Articles", type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
+
+    context 'when user isn\'t authenticated' do
+      it "responds with status 302" do
+        post signout_path
+
+        post articles_path, params: {article: {title: "title", body: nil}}
+        expect(response).to have_http_status(302)
   end
 
   describe "PUT /articles/:id" do

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -67,7 +67,19 @@ RSpec.describe "Articles", type: :request do
 
         post articles_path, params: {article: {title: "title", body: nil}}
         expect(response).to have_http_status(302)
+      end
+    end
   end
+
+  describe 'GET /articles/:id/edit' do
+    let(:article) { FactoryBot.create(:article, profile: user.profile) }
+
+    it 'responds with status 200' do
+      get edit_article_path(article)
+      expect(response).to have_http_status(200)
+    end
+  end
+  
 
   describe "PUT /articles/:id" do
     let(:article) { FactoryBot.create(:article, profile: user.profile) }

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -70,11 +70,21 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "PUT /articles/:id" do
-    let!(:article) {FactoryBot.create(:article)}
+    let(:article) { FactoryBot.create(:article, profile: user.profile) }
+    let(:put_article) { put "/articles/#{article.slug}", :params => {:article => {:title => "new title", :body => "new body"}} }
 
-    it "responds with :redirect status" do
-      put "/articles/#{article.slug}", :params => {:article => {:title => "new title", :body => "new body"}}
+    it "responds with status 302" do
+      put_article
+      expect(response).to have_http_status(302)
+    end
 
+    context 'when unauthorized' do
+      let!(:second_user) { FactoryBot.create(:user) }
+
+      it "responds with status 401" do
+        post signout_path
+        post sessions_path, params: {email: second_user.email, password: second_user.password}
+        
       expect(response).to have_http_status(:redirect)
     end
   end


### PR DESCRIPTION
- feat: allows unauthenticated user to access :index and :show
- feat: adds method is_unauthorized?
- feat: adds belongs_to :profile
- feat: adds has_many :articles
- db: creates migration to add foreign key to articles
- db: updates schema after AddForgeinKeyToArticles
- fix: adds profile for article
- test: POST /articles when user isn't authenticated responds with status 302
- test: PUT /articles/:id when user unauthorized responds with status 401
- test: DELETE /articles/:id when user unauthorized responds with status 401
- test: GET /articles/:id/edit responds with status 200
- fix: adds profile for article
